### PR TITLE
Take into account differences between OSs in cp -r command.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,9 @@ build: build_dataset build_go build_dart
 build_dataset: dist/national_elb
 
 dist/national_elb: make_dataset/geodata/national_elb
-	mkdir -p dist/national_elb
-	cp -vr make_dataset/geodata/national_elb/ dist/national_elb/
+	mkdir -p dist
+	# Note trailing slashes on the source are significant on BSD systems (i.e. OS X).
+	cp -vr make_dataset/geodata/national_elb dist/
 	touch dist/national_elb
 
 make_dataset/geodata/national_elb:


### PR DESCRIPTION
See: http://jondavidjohn.com/linux-vs-osx-the-cp-command/
This fixes the wrong dist/national_elb/national_elb directory structure on Linux.
