### PR TITLE
fix error - go_backend/encoded_polyline.go:100:3: cannot use f.ID (ty…

### DIFF
--- a/go_backend/encoded_polyline.go
+++ b/go_backend/encoded_polyline.go
@@ -97,7 +97,7 @@ func convertToEncodedPolylineFeature(f *geojson.Feature) (*EncodedPolylineFeatur
 		Coordinates: encodedMultiPolygon,
 	}
 	return &EncodedPolylineFeature{
-		ID:          f.ID,
+		ID:          f.ID.(string),
 		Type:        f.Type,
 		BoundingBox: f.BoundingBox,
 		Geometry:    encodedGeom,


### PR DESCRIPTION
…pe interface {}) as type string in field value: need type assertion

probably caused by upstream change to paulmach/go.geojson due to the following commit:
Commit link https://github.com/paulmach/go.geojson/commit/2adc13edeac8c96d031e7ad6b7250a5795367c8c